### PR TITLE
Update kubernetes deployment files to update images to latest

### DIFF
--- a/kubernetes-deployment.yaml
+++ b/kubernetes-deployment.yaml
@@ -15,7 +15,8 @@ spec:
         app: frontend
     spec:
       containers:
-      - image: rasmj/frontend
+      - image: rasmj/frontend:latest
+        imagePullPolicy: Always
         name: frontend
         env:
         - name: BACKEND_DNS
@@ -59,7 +60,8 @@ spec:
         app: backend
     spec:
       containers:
-      - image: rasmj/backend
+      - image: rasmj/backend:latest
+        imagePullPolicy: Always
         name: backend
         env:
         - name: REDIS_DNS

--- a/kubernetes-dev-deployment.yaml
+++ b/kubernetes-dev-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       containers:
       - image: rasmj/frontend:latest-dev
+        imagePullPolicy: Always
         name: frontend
         env:
         - name: BACKEND_DNS
@@ -60,6 +61,7 @@ spec:
     spec:
       containers:
       - image: rasmj/backend:latest-dev
+        imagePullPolicy: Always
         name: backend
         env:
         - name: REDIS_DNS

--- a/kubernetes-stag-deployment.yaml
+++ b/kubernetes-stag-deployment.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       containers:
       - image: rasmj/frontend:latest-stag
+        imagePullPolicy: Always
         name: frontend
         env:
         - name: BACKEND_DNS
@@ -60,6 +61,7 @@ spec:
     spec:
       containers:
       - image: rasmj/backend:latest-stag
+        imagePullPolicy: Always
         name: backend
         env:
         - name: REDIS_DNS


### PR DESCRIPTION
Added `imagePullPolicy: true` to kubernetes deployment files so that the kubernetes deployment updates when new Docker images get pushed to Docker Hub